### PR TITLE
Harmonize add_port_mapping

### DIFF
--- a/src/nat.hrl
+++ b/src/nat.hrl
@@ -1,7 +1,7 @@
 -define(NAT_TRIES, 5).
 -define(NAT_INITIAL_MS, 250).
 
--define(RECOMMENDED_MAPPING_LIFETIME_SECONDS, 0).
+-define(RECOMMENDED_MAPPING_LIFETIME_SECONDS, 3600).
 
 -record(nat_upnp, {
           service_url,

--- a/src/nat.hrl
+++ b/src/nat.hrl
@@ -1,7 +1,7 @@
 -define(NAT_TRIES, 5).
 -define(NAT_INITIAL_MS, 250).
 
--define(RECOMMENDED_MAPPING_LIFETIME_SECONDS, 3600).
+-define(RECOMMENDED_MAPPING_LIFETIME_SECONDS, 0).
 
 -record(nat_upnp, {
           service_url,

--- a/src/nat_scan.erl
+++ b/src/nat_scan.erl
@@ -67,9 +67,7 @@ natupnp_v1() ->
 
             case natupnp_v1:get_internal_address(Context) of
                 {ok, IntAddress} ->
-                    ?LOG("[natupnp_v1] got internal address ~p", [IntAddress]);
-                {error, R3} ->
-                    ?LOG("[natupnp_v1] failed to get internal address ~p", [R3])
+                    ?LOG("[natupnp_v1] got internal address ~p", [IntAddress])
             end;
         timeout ->
             ?LOG("[natupnp_v1] failed to discover timeout", []);
@@ -105,9 +103,7 @@ natupnp_v2() ->
 
             case natupnp_v2:get_internal_address(Context) of
                 {ok, IntAddress} ->
-                    ?LOG("[natupnp_v2] got internal address ~p", [IntAddress]);
-                {error, R3} ->
-                    ?LOG("[natupnp_v2] failed to get internal address ~p", [R3])
+                    ?LOG("[natupnp_v2] got internal address ~p", [IntAddress])
             end;
         timeout ->
             ?LOG("[natupnp_v2] failed to discover timeout", []);
@@ -143,12 +139,8 @@ natpmp() ->
 
             case natpmp:get_internal_address(Context) of
                 {ok, IntAddress} ->
-                    ?LOG("[natpmp] got internal address ~p", [IntAddress]);
-                {error, R3} ->
-                    ?LOG("[natpmp] failed to get internal address ~p", [R3])
+                    ?LOG("[natpmp] got internal address ~p", [IntAddress])
             end;
         no_nat ->
-            ?LOG("[natpmp] failed to discover not nat", []);
-        {error, _Reason} ->
-            ?LOG("[natpmp] failed to discover ~p", [_Reason])
+            ?LOG("[natpmp] failed to discover not nat", [])
     end.

--- a/src/nat_scan.erl
+++ b/src/nat_scan.erl
@@ -69,8 +69,6 @@ natupnp_v1() ->
                 {ok, IntAddress} ->
                     ?LOG("[natupnp_v1] got internal address ~p", [IntAddress])
             end;
-        timeout ->
-            ?LOG("[natupnp_v1] failed to discover timeout", []);
         {error, _Reason} ->
             ?LOG("[natupnp_v1] failed to discover ~p", [_Reason])
     end.
@@ -105,8 +103,6 @@ natupnp_v2() ->
                 {ok, IntAddress} ->
                     ?LOG("[natupnp_v2] got internal address ~p", [IntAddress])
             end;
-        timeout ->
-            ?LOG("[natupnp_v2] failed to discover timeout", []);
         {error, _Reason} ->
             ?LOG("[natupnp_v2] failed to discover ~p", [_Reason])
     end.
@@ -141,6 +137,6 @@ natpmp() ->
                 {ok, IntAddress} ->
                     ?LOG("[natpmp] got internal address ~p", [IntAddress])
             end;
-        no_nat ->
+        {error, no_nat} ->
             ?LOG("[natpmp] failed to discover not nat", [])
     end.

--- a/src/natpmp.erl
+++ b/src/natpmp.erl
@@ -44,10 +44,9 @@ get_external_address(Gateway) ->
 	nat_rpc(Gateway, Msg, 0).
 
 %% @doc get internal address used for this gateway
--spec get_internal_address(Gateway) -> {ok, InternalIp} | {error, Reason} when
+-spec get_internal_address(Gateway) -> {ok, InternalIp} when
 	Gateway :: inet:ip_address() | inet:hostname(),
-    InternalIp :: inet:ip_address() | inet:hostname(),
-    Reason :: any().
+    InternalIp :: inet:ip_address() | inet:hostname().
 get_internal_address(Gateway) ->
     {ok, inet_ext:get_internal_address(Gateway)}.
 
@@ -85,9 +84,8 @@ system_gateways() ->
     [Ip || {_, Ip} <- inet_ext:gateways()].
 
 %% @doc discover a Nat gateway
--spec discover() -> {ok, Gateway} | {error, Reason} when
-      Gateway :: inet:ip_address(),
-      Reason :: any().
+-spec discover() -> {ok, Gateway} | no_nat when
+      Gateway :: inet:ip_address().
 discover() ->
     IPs = case system_gateways() of
               [] ->  potential_gateways();

--- a/src/natpmp.erl
+++ b/src/natpmp.erl
@@ -84,7 +84,7 @@ system_gateways() ->
     [Ip || {_, Ip} <- inet_ext:gateways()].
 
 %% @doc discover a Nat gateway
--spec discover() -> {ok, Gateway} | no_nat when
+-spec discover() -> {ok, Gateway} | {error, any()} when
       Gateway :: inet:ip_address().
 discover() ->
     IPs = case system_gateways() of
@@ -106,7 +106,7 @@ discover() ->
      discover_wait(Workers, Ref).
 
 discover_wait([], _Ref) ->
-    no_nat;
+    {error, no_nat};
 discover_wait(Workers, Ref) ->
     receive
         {nat, Ref, WorkerPid, GatewayIp} ->

--- a/src/natupnp_v1.erl
+++ b/src/natupnp_v1.erl
@@ -125,8 +125,6 @@ add_port_mapping(Context, Protocol, InternalPort, ExternalPort) ->
                        Protocol:: nat:nat_protocol(), InternalPort :: integer(),
                        ExternalPort :: integer(),
                        Lifetime :: integer()) -> ok | {error, term()}.
-add_port_mapping(Ctx, Protocol, InternalPort, ExternalPort, 0) ->
-    delete_port_mapping(Ctx, Protocol, InternalPort, ExternalPort);
 add_port_mapping(Ctx, Protocol0, InternalPort, ExternalPort, Lifetime) ->
     Protocol = protocol(Protocol0),
     case ExternalPort of

--- a/src/natupnp_v1.erl
+++ b/src/natupnp_v1.erl
@@ -23,7 +23,8 @@
 
 %% @doc discover the gateway and our IP to associate
 -spec discover() -> {ok, Context:: nat:nat_upnp()}
-                    | {error, term()}.
+                    | {error, term()}
+                    | timeout.
 discover() ->
     _ = application:start(inets),
     _ = rand_compat:seed(erlang:phash2([node()]),
@@ -112,19 +113,16 @@ get_internal_address(#nat_upnp{ip=Ip}) ->
     {ok, Ip}.
 
 
-%% @doc Add a port mapping with default lifetime to 3600 seconds
--spec add_port_mapping(Context :: nat:nat_upnp(),
-                       Protocol:: nat:nat_protocol(), ExternalPort :: integer(),
-                       InternalPort :: integer()) -> ok | {error, term()}.
+%% @doc Add a port mapping with default lifetime to 0 seconds
+-spec add_port_mapping(nat:nat_upnp(), nat:nat_protocol(), integer(), integer()) ->
+    {ok, non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | {error, any()}.
 add_port_mapping(Context, Protocol, InternalPort, ExternalPort) ->
     add_port_mapping(Context, Protocol, InternalPort, ExternalPort,
                      ?RECOMMENDED_MAPPING_LIFETIME_SECONDS).
 
 %% @doc Add a port mapping and release after Timeout
--spec add_port_mapping(Context :: nat:nat_upnp(),
-                       Protocol:: nat:nat_protocol(), InternalPort :: integer(),
-                       ExternalPort :: integer(),
-                       Lifetime :: integer()) -> ok | {error, term()}.
+-spec add_port_mapping(nat:nat_upnp(), nat:nat_protocol(),integer(), integer(), integer()) ->
+    {ok, non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | {error, any()}.
 add_port_mapping(Ctx, Protocol0, InternalPort, ExternalPort, Lifetime) ->
     Protocol = protocol(Protocol0),
     case ExternalPort of

--- a/src/natupnp_v1.erl
+++ b/src/natupnp_v1.erl
@@ -23,8 +23,7 @@
 
 %% @doc discover the gateway and our IP to associate
 -spec discover() -> {ok, Context:: nat:nat_upnp()}
-                    | {error, term()}
-                    | timeout.
+                    | {error, term()}.
 discover() ->
     _ = application:start(inets),
     _ = rand_compat:seed(erlang:phash2([node()]),
@@ -49,7 +48,7 @@ discover() ->
 
 
 discover1(_Sock, _MSearch, ?NAT_TRIES) ->
-    timeout;
+    {error, timeout};
 discover1(Sock, MSearch, Tries) ->
     inet:setopts(Sock, [{active, once}]),
     Timeout = ?NAT_INITIAL_MS bsl Tries,

--- a/src/natupnp_v2.erl
+++ b/src/natupnp_v2.erl
@@ -24,7 +24,8 @@
 
 %% @doc discover the gateway and our IP to associate
 -spec discover() -> {ok, Context:: nat:nat_upnp()}
-                    | {error, term()}.
+                    | {error, term()}
+                    | timeout.
 discover() ->
     _ = application:start(inets),
     _ = rand_compat:seed(erlang:phash2([node()]),
@@ -118,19 +119,16 @@ get_internal_address(#nat_upnp{ip=Ip}) ->
     {ok, Ip}.
 
 
-%% @doc Add a port mapping with default lifetime to 3600 seconds
--spec add_port_mapping(Context :: nat:nat_upnp(),
-                       Protocol:: nat:nat_protocol(), ExternalPort :: integer(),
-                       InternalPort :: integer()) -> ok | {error, term()}.
+%% @doc Add a port mapping with default lifetime to 0 seconds
+-spec add_port_mapping(nat:nat_upnp(), nat:nat_protocol(), integer(), integer()) ->
+    {ok, non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | {error, any()}.
 add_port_mapping(Context, Protocol, InternalPort, ExternalPort) ->
     add_port_mapping(Context, Protocol, InternalPort, ExternalPort,
                      ?RECOMMENDED_MAPPING_LIFETIME_SECONDS).
 
 %% @doc Add a port mapping and release after Timeout
--spec add_port_mapping(Context :: nat:nat_upnp(),
-                       Protocol:: nat:nat_protocol(), InternalPort :: integer(),
-                       ExternalPort :: integer(),
-                       Lifetime :: integer()) -> ok | {error, term()}.
+-spec add_port_mapping(nat:nat_upnp(), nat:nat_protocol(),integer(), integer(), integer()) ->
+    {ok, non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | {error, any()}.
 add_port_mapping(Ctx, Protocol0, InternalPort, ExternalPort, Lifetime) ->
     Protocol = protocol(Protocol0),
     case ExternalPort of

--- a/src/natupnp_v2.erl
+++ b/src/natupnp_v2.erl
@@ -131,8 +131,6 @@ add_port_mapping(Context, Protocol, InternalPort, ExternalPort) ->
                        Protocol:: nat:nat_protocol(), InternalPort :: integer(),
                        ExternalPort :: integer(),
                        Lifetime :: integer()) -> ok | {error, term()}.
-add_port_mapping(Ctx, Protocol, InternalPort, ExternalPort, 0) ->
-    add_port_mapping(Ctx, Protocol, InternalPort, ExternalPort, 604800);
 add_port_mapping(Ctx, Protocol0, InternalPort, ExternalPort, Lifetime) ->
     Protocol = protocol(Protocol0),
     case ExternalPort of

--- a/src/natupnp_v2.erl
+++ b/src/natupnp_v2.erl
@@ -24,8 +24,7 @@
 
 %% @doc discover the gateway and our IP to associate
 -spec discover() -> {ok, Context:: nat:nat_upnp()}
-                    | {error, term()}
-                    | timeout.
+                    | {error, term()}.
 discover() ->
     _ = application:start(inets),
     _ = rand_compat:seed(erlang:phash2([node()]),
@@ -49,7 +48,7 @@ discover() ->
     end.
 
 discover1(_Sock, _MSearch, ?NAT_TRIES) ->
-    timeout;
+    {error, timeout};
 discover1(Sock, MSearch, Tries) ->
     inet:setopts(Sock, [{active, once}]),
     Timeout = ?NAT_INITIAL_MS bsl Tries,


### PR DESCRIPTION
1. Harmonize `add_port_mapping` when `LifeTime` is 0.
2. Set default lifetime to 0 (as mentioned in #5).
3. Dialyzer fixes.