### PR TITLE
Add missing dependancies to app.src

### DIFF
--- a/src/nat.app.src
+++ b/src/nat.app.src
@@ -3,7 +3,7 @@
 	{vsn, "0.3.0"},
 	{modules, []},
 	{registered, []},
-	{applications, [kernel,stdlib,inet_cidr,inet_ext]},
+	{applications, [kernel,stdlib,inet_cidr,inet_ext,inets,xmerl,rand_compat]},
   {maintainers, ["Benoit Chesneau"]},
   {licenses, ["MIT"]},
   {links, [{"Github", "https://github.com/benoitc/erlang-nat"}]},


### PR DESCRIPTION
erlang-nat depends on httpc (from inets), xmerl and rand_compat. These should appear in the .app.src file so that releases will correctly include them.