### PR TITLE
handle case where multiple UPNP services answers

### DIFF
--- a/src/nat_lib.erl
+++ b/src/nat_lib.erl
@@ -10,6 +10,7 @@
 -export([soap_request/3, soap_request/4]).
 -export([random_port/0]).
 -export([timestamp/0]).
+-export([get_headers/1, get_headers/2]).
 
 soap_request(Url, Function, Msg0) ->
   soap_request(Url, Function, Msg0, []).
@@ -58,3 +59,16 @@ erlang_ts() ->
         error:undef ->
             erlang:now()
     end.
+
+get_headers(Raw) ->
+  get_headers(Raw, #{}).
+
+get_headers(Raw, Headers) ->
+  case erlang:decode_packet(httph_bin, Raw, []) of
+    {ok, {http_error, _}, Rest} ->
+      get_headers(Rest, Headers);
+    {ok, {http_header, _, H, _, V}, Rest} ->
+      get_headers(Rest, Headers#{ H => V });
+    _ ->
+      Headers
+  end.


### PR DESCRIPTION
in some infrastructure with badly configured UPNP,
you can multiple response for a request. This change make sure we will
retrieve one response from the router at least instead of only waiting
for the first packet.

fix #17