### PR TITLE
Allow a wildcard namespace for GetExternalIPAddressResponse

### DIFF
--- a/src/natupnp_v1.erl
+++ b/src/natupnp_v1.erl
@@ -114,7 +114,7 @@ get_external_address(#nat_upnp{service_url=Url}) ->
             {Xml, _} = xmerl_scan:string(Body, [{space, normalize}]),
 
             [Infos | _] = xmerl_xpath:string("//s:Envelope/s:Body/"
-                                             "u:GetExternalIPAddressResponse", Xml),
+                                             "*[local-name() = 'GetExternalIPAddressResponse']", Xml),
 
             IP = extract_txt(
                    xmerl_xpath:string("NewExternalIPAddress/text()",


### PR DESCRIPTION
Should be a fix for #19.